### PR TITLE
adds schema attribute

### DIFF
--- a/11.json
+++ b/11.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.11",
   "type": "object",
   "properties": {

--- a/11.json
+++ b/11.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.11",
   "type": "object",
   "properties": {

--- a/12.json
+++ b/12.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.12",
   "type": "object",
   "properties": {

--- a/12.json
+++ b/12.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.12",
   "type": "object",
   "properties": {

--- a/13.json
+++ b/13.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.13",
   "type": "object",
   "properties": {

--- a/13.json
+++ b/13.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.13",
   "type": "object",
   "properties": {

--- a/14-draft.json
+++ b/14-draft.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.14",
   "type": "object",
   "properties": {

--- a/14-draft.json
+++ b/14-draft.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.14",
   "type": "object",
   "properties": {

--- a/8.json
+++ b/8.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.8",
   "type": "object",
   "properties": {

--- a/8.json
+++ b/8.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.8",
   "type": "object",
   "properties": {

--- a/9.json
+++ b/9.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "description": "SpaceAPI 0.9",
   "type": "object",
   "properties": {

--- a/9.json
+++ b/9.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "SpaceAPI 0.9",
   "type": "object",
   "properties": {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # SpaceAPI Schema Files
 
-These are JSON Schema files (IETF Draft 04) for the SpaceAPI.
+These are JSON Schema files (IETF Draft 06) for the SpaceAPI.


### PR DESCRIPTION
The schema attribute should be provided to all schema files, more information can be found [here](http://json-schema.org/latest/json-schema-core.html#rfc.section.7) and [here](https://spacetelescope.github.io/understanding-json-schema/reference/schema.html)
